### PR TITLE
(For Mohammed) Add exponential backoff for resilience4j circuits

### DIFF
--- a/resilience4j-circuitbreaker/src/main/java/io/github/resilience4j/circuitbreaker/CircuitBreakerConfig.java
+++ b/resilience4j-circuitbreaker/src/main/java/io/github/resilience4j/circuitbreaker/CircuitBreakerConfig.java
@@ -18,6 +18,7 @@
  */
 package io.github.resilience4j.circuitbreaker;
 
+import io.github.resilience4j.core.IntervalFunction;
 import io.github.resilience4j.core.lang.Nullable;
 import io.github.resilience4j.core.predicate.PredicateCreator;
 
@@ -45,6 +46,7 @@ public class CircuitBreakerConfig {
     private int ringBufferSizeInHalfOpenState = DEFAULT_RING_BUFFER_SIZE_IN_HALF_OPEN_STATE;
     private int ringBufferSizeInClosedState = DEFAULT_RING_BUFFER_SIZE_IN_CLOSED_STATE;
     private Duration waitDurationInOpenState = Duration.ofSeconds(DEFAULT_WAIT_DURATION_IN_OPEN_STATE);
+    private IntervalFunction waitIntervalFunctionInOpenState = null;
     // The default exception predicate counts all exceptions as failures.
     private Predicate<Throwable> recordFailurePredicate = DEFAULT_RECORD_FAILURE_PREDICATE;
     private boolean automaticTransitionFromOpenToHalfOpenEnabled = false;
@@ -87,6 +89,8 @@ public class CircuitBreakerConfig {
         return waitDurationInOpenState;
     }
 
+    public IntervalFunction getWaitIntervalFunctionInOpenState() { return waitIntervalFunctionInOpenState; }
+
     public int getRingBufferSizeInHalfOpenState() {
         return ringBufferSizeInHalfOpenState;
     }
@@ -114,10 +118,12 @@ public class CircuitBreakerConfig {
         private int ringBufferSizeInHalfOpenState = DEFAULT_RING_BUFFER_SIZE_IN_HALF_OPEN_STATE;
         private int ringBufferSizeInClosedState = DEFAULT_RING_BUFFER_SIZE_IN_CLOSED_STATE;
         private Duration waitDurationInOpenState = Duration.ofSeconds(DEFAULT_WAIT_DURATION_IN_OPEN_STATE);
+        private IntervalFunction waitIntervalFunctionInOpenState = null;
         private boolean automaticTransitionFromOpenToHalfOpenEnabled = false;
 
         public Builder(CircuitBreakerConfig baseConfig) {
             this.waitDurationInOpenState = baseConfig.waitDurationInOpenState;
+            this.waitIntervalFunctionInOpenState = baseConfig.waitIntervalFunctionInOpenState;
             this.ringBufferSizeInHalfOpenState = baseConfig.ringBufferSizeInHalfOpenState;
             this.ringBufferSizeInClosedState = baseConfig.ringBufferSizeInClosedState;
             this.failureRateThreshold = baseConfig.failureRateThreshold;
@@ -159,6 +165,16 @@ public class CircuitBreakerConfig {
                 throw new IllegalArgumentException("waitDurationInOpenState must be at least 1[ms]");
             }
             this.waitDurationInOpenState = waitDurationInOpenState;
+            return this;
+        }
+
+        /**
+         * configures the variable wait duration which specifies how long the CircuitBreaker should stay open, before it switches to half open. Useful for exponential back-off
+         * @param waitIntervalFunctionInOpenState Interval function that returns wait time as a function of attempts
+         * @return the CircuitBreakerConfig.Builder
+         */
+        public Builder waitIntervalFunctionInOpenState(IntervalFunction waitIntervalFunctionInOpenState) {
+            this.waitIntervalFunctionInOpenState = waitIntervalFunctionInOpenState;
             return this;
         }
 
@@ -286,6 +302,7 @@ public class CircuitBreakerConfig {
         public CircuitBreakerConfig build() {
             CircuitBreakerConfig config = new CircuitBreakerConfig();
             config.waitDurationInOpenState = waitDurationInOpenState;
+            config.waitIntervalFunctionInOpenState = waitIntervalFunctionInOpenState;
             config.failureRateThreshold = failureRateThreshold;
             config.ringBufferSizeInClosedState = ringBufferSizeInClosedState;
             config.ringBufferSizeInHalfOpenState = ringBufferSizeInHalfOpenState;

--- a/resilience4j-core/src/main/java/io/github/resilience4j/core/IntervalFunction.java
+++ b/resilience4j-core/src/main/java/io/github/resilience4j/core/IntervalFunction.java
@@ -1,11 +1,11 @@
-package io.github.resilience4j.retry;
+package io.github.resilience4j.core;
 
 import io.vavr.collection.Stream;
 
 import java.time.Duration;
 import java.util.function.Function;
 
-import static io.github.resilience4j.retry.IntervalFunctionCompanion.*;
+import static io.github.resilience4j.core.IntervalFunctionCompanion.*;
 import static java.util.Objects.requireNonNull;
 
 @FunctionalInterface

--- a/resilience4j-core/src/test/java/io/github/resilience4j/core/IntervalFunctionTest.java
+++ b/resilience4j-core/src/test/java/io/github/resilience4j/core/IntervalFunctionTest.java
@@ -1,4 +1,4 @@
-package io.github.resilience4j.retry;
+package io.github.resilience4j.core;
 
 import io.vavr.collection.List;
 import io.vavr.control.Try;

--- a/resilience4j-framework-common/src/main/java/io/github/resilience4j/common/retry/configuration/RetryConfigurationProperties.java
+++ b/resilience4j-framework-common/src/main/java/io/github/resilience4j/common/retry/configuration/RetryConfigurationProperties.java
@@ -27,9 +27,9 @@ import org.hibernate.validator.constraints.time.DurationMin;
 import io.github.resilience4j.common.utils.ConfigUtils;
 import io.github.resilience4j.core.ClassUtils;
 import io.github.resilience4j.core.ConfigurationNotFoundException;
+import io.github.resilience4j.core.IntervalFunction;
 import io.github.resilience4j.core.StringUtils;
 import io.github.resilience4j.core.lang.Nullable;
-import io.github.resilience4j.retry.IntervalFunction;
 import io.github.resilience4j.retry.RetryConfig;
 
 /**

--- a/resilience4j-retry/src/main/java/io/github/resilience4j/retry/RetryConfig.java
+++ b/resilience4j-retry/src/main/java/io/github/resilience4j/retry/RetryConfig.java
@@ -19,6 +19,7 @@
 package io.github.resilience4j.retry;
 
 
+import io.github.resilience4j.core.IntervalFunction;
 import io.github.resilience4j.core.lang.Nullable;
 import io.github.resilience4j.core.predicate.PredicateCreator;
 

--- a/resilience4j-retry/src/main/java/io/github/resilience4j/retry/internal/RetryImpl.java
+++ b/resilience4j-retry/src/main/java/io/github/resilience4j/retry/internal/RetryImpl.java
@@ -20,6 +20,7 @@ package io.github.resilience4j.retry.internal;
 
 import io.github.resilience4j.core.EventConsumer;
 import io.github.resilience4j.core.EventProcessor;
+import io.github.resilience4j.core.IntervalFunction;
 import io.github.resilience4j.core.lang.Nullable;
 import io.github.resilience4j.retry.Retry;
 import io.github.resilience4j.retry.RetryConfig;

--- a/resilience4j-retry/src/test/java/io/github/resilience4j/retry/internal/RunnableRetryTest.java
+++ b/resilience4j-retry/src/test/java/io/github/resilience4j/retry/internal/RunnableRetryTest.java
@@ -18,7 +18,7 @@
  */
 package io.github.resilience4j.retry.internal;
 
-import io.github.resilience4j.retry.IntervalFunction;
+import io.github.resilience4j.core.IntervalFunction;
 import io.github.resilience4j.retry.Retry;
 import io.github.resilience4j.retry.RetryConfig;
 import io.github.resilience4j.test.HelloWorldService;

--- a/resilience4j-retry/src/test/java/io/github/resilience4j/retry/internal/SupplierRetryTest.java
+++ b/resilience4j-retry/src/test/java/io/github/resilience4j/retry/internal/SupplierRetryTest.java
@@ -37,7 +37,7 @@ import org.junit.Test;
 import org.mockito.BDDMockito;
 import org.mockito.Mockito;
 
-import io.github.resilience4j.retry.IntervalFunction;
+import io.github.resilience4j.core.IntervalFunction;
 import io.github.resilience4j.retry.Retry;
 import io.github.resilience4j.retry.RetryConfig;
 import io.github.resilience4j.test.AsyncHelloWorldService;


### PR DESCRIPTION
**Purpose**
- To allow exponential backoff of resilience4j circuit breaker

**Technical Overview**
- Refactor IntervalFunction to be accessible in Core
- Add parameter in circuit breaker to accept interval function for it's open state wait period
- Keep track of retries for opening circuit as part of circuit state machine
- Pass number of retries to interval function to determine open state wait time

**Tests**
- Tested in several game days
- Added unit test in project

**Deployment plan**
This is a library that will be used in 3rd party sift folder, deployment will be done in a later PR

**Rollback**
No deployment associated with this PR